### PR TITLE
Add probability calibration and evaluation utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
   "openai>=1.101",
   "pydantic-ai-slim[openai]>=0.0.16",
   "sqlalchemy>=2.0.43",
+  "scikit-learn>=1.5",
+  "matplotlib>=3.9",
 ]
 
 [project.optional-dependencies]

--- a/scripts/analyze_performance.py
+++ b/scripts/analyze_performance.py
@@ -1,5 +1,13 @@
-import argparse, sqlite3, pandas as pd
+import argparse
+import sqlite3
 from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from sklearn.calibration import calibration_curve
+from sklearn.metrics import brier_score_loss
+
+from swing_agent.calibration import calibrated_winrate, load_calibrator
 
 def main():
     ap = argparse.ArgumentParser()
@@ -7,11 +15,16 @@ def main():
     args = ap.parse_args()
     db = Path(args.db)
     with sqlite3.connect(db) as con:
-        df = pd.read_sql_query("""
+        df = pd.read_sql_query(
+            """
             SELECT symbol, timeframe, asof, side, expected_r, expected_winrate,
-                   expected_hold_bars, realized_r, exit_reason, mtf_alignment, rs_sector_20, vol_regime
+                   expected_hold_bars, realized_r, exit_reason, mtf_alignment,
+                   rs_sector_20, vol_regime
             FROM signals WHERE evaluated = 1
-        """, con, parse_dates=["asof"])
+            """,
+            con,
+            parse_dates=["asof"],
+        )
     if df.empty:
         print("No evaluated signals yet."); return
     g = df.groupby(["vol_regime"]).agg(
@@ -22,12 +35,35 @@ def main():
     ).reset_index()
     print("=== Performance by vol_regime ===")
     print(g.to_string(index=False))
-    df = df.dropna(subset=["expected_winrate"])
-    if not df.empty:
-        df["bin"] = (df["expected_winrate"]*10).clip(0,9).astype(int)/10.0
-        cal = df.groupby("bin").agg(n=("symbol","count"), pred=("expected_winrate","mean"), emp=("realized_r", lambda s: (s>0).mean())).reset_index().sort_values("bin")
-        print("\n=== Calibration (winrate) ===")
-        print(cal.to_string(index=False))
+    df = df.dropna(subset=["expected_winrate", "realized_r"])
+    if df.empty:
+        return
+
+    y_true = (df["realized_r"] > 0).astype(int)
+    y_pred = df["expected_winrate"].clip(0, 1)
+    brier_raw = brier_score_loss(y_true, y_pred)
+
+    # Fit calibrator and apply if available
+    model = load_calibrator(db)
+    if model is not None:
+        df["calibrated"] = df["expected_winrate"].apply(lambda p: calibrated_winrate(p, db))
+        brier_cal = brier_score_loss(y_true, df["calibrated"])
+        print(f"\nBrier score (raw/calibrated): {brier_raw:.4f}/{brier_cal:.4f}")
+        prob_true_raw, prob_pred_raw = calibration_curve(y_true, y_pred, n_bins=10)
+        prob_true_cal, prob_pred_cal = calibration_curve(y_true, df["calibrated"], n_bins=10)
+        plt.plot(prob_pred_raw, prob_true_raw, marker="o", label="raw")
+        plt.plot(prob_pred_cal, prob_true_cal, marker="o", label="calibrated")
+    else:
+        print(f"\nBrier score: {brier_raw:.4f}")
+        prob_true_raw, prob_pred_raw = calibration_curve(y_true, y_pred, n_bins=10)
+        plt.plot(prob_pred_raw, prob_true_raw, marker="o", label="raw")
+
+    plt.plot([0, 1], [0, 1], "k--", label="ideal")
+    plt.xlabel("Predicted probability")
+    plt.ylabel("Empirical probability")
+    plt.title("Calibration curve")
+    plt.legend()
+    plt.show()
 
 if __name__ == "__main__":
     main()

--- a/src/swing_agent/agent.py
+++ b/src/swing_agent/agent.py
@@ -12,6 +12,7 @@ from .llm_predictor import llm_extra_prediction, llm_build_action_plan
 from .features import build_setup_vector, time_of_day_bucket, vol_regime_from_series
 from .vectorstore import add_vector, knn, extended_stats, filter_neighbors
 from .storage import record_signal
+from .calibration import calibrated_winrate
 
 def _clip01(x: float) -> float:
     """Clip a value to the range [0, 1].
@@ -665,7 +666,13 @@ class SwingAgent:
             llm_explanation=llm_insights.get("llm_explanation"),
             expected_r=(round(ml_expectations["expected_r"], 3) 
                        if ml_expectations["expected_r"] is not None else None),
-            expected_winrate=ml_expectations["expected_winrate"],
+            expected_winrate=(
+                calibrated_winrate(
+                    ml_expectations["expected_winrate"], self.log_db
+                )
+                if ml_expectations["expected_winrate"] is not None
+                else None
+            ),
             expected_source=("vector_knn/v1.6.1" if self.vec_db is not None else None),
             expected_notes=("E[R]=p*avg_win+(1-p)*avg_loss; med hold from KNN neighbors (filtered by vol_regime)." 
                           if self.vec_db is not None else None),

--- a/src/swing_agent/calibration.py
+++ b/src/swing_agent/calibration.py
@@ -1,0 +1,85 @@
+"""Probability calibration utilities for SwingAgent.
+
+This module provides a simple interface for calibrating predicted win
+rates using historical signal outcomes. It fits an isotonic regression
+model on past predictions and realized results and exposes a
+``calibrated_winrate`` function used by :mod:`agent` before signals are
+stored.
+
+The calibration model is loaded lazily from the signals database.  If
+insufficient data is available the input probability is returned
+unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+import sqlite3
+
+import numpy as np
+import pandas as pd
+from sklearn.isotonic import IsotonicRegression
+
+__all__ = ["calibrated_winrate", "load_calibrator"]
+
+
+_model: Optional[IsotonicRegression] = None
+_model_db: Optional[Path] = None
+
+
+def _fit_model(db_path: Path) -> Optional[IsotonicRegression]:
+    """Fit an isotonic regression model from historical signals.
+
+    Parameters
+    ----------
+    db_path:
+        Path to the SQLite database containing the ``signals`` table.
+
+    Returns
+    -------
+    Optional[IsotonicRegression]
+        Fitted model or ``None`` if there is insufficient data.
+    """
+    query = (
+        "SELECT expected_winrate, realized_r FROM signals "
+        "WHERE evaluated = 1 AND expected_winrate IS NOT NULL "
+        "AND realized_r IS NOT NULL"
+    )
+    try:
+        with sqlite3.connect(db_path) as con:
+            df = pd.read_sql_query(query, con)
+    except Exception:
+        return None
+
+    if len(df) < 20:
+        return None
+
+    y = (df["realized_r"] > 0).astype(float).to_numpy()
+    p = df["expected_winrate"].clip(0, 1).to_numpy()
+    model = IsotonicRegression(out_of_bounds="clip")
+    model.fit(p, y)
+    return model
+
+
+def load_calibrator(db_path: str | Path = "data/swing_agent.sqlite") -> Optional[IsotonicRegression]:
+    """Load (or fit) the calibration model for the given database."""
+    global _model, _model_db
+    db = Path(db_path)
+    if _model is None or _model_db != db:
+        _model = _fit_model(db)
+        _model_db = db
+    return _model
+
+
+def calibrated_winrate(prob: float, db_path: str | Path = "data/swing_agent.sqlite") -> float:
+    """Return calibrated win rate for the given probability.
+
+    If a calibration model is available, the probability is transformed
+    using isotonic regression; otherwise it is returned unchanged.
+    """
+    model = load_calibrator(db_path)
+    prob = float(prob)
+    if model is None:
+        return prob
+    return float(model.predict(np.array([prob]))[0])


### PR DESCRIPTION
## Summary
- add isotonic regression calibration module for win rate predictions
- apply calibration before saving signals
- report Brier score and visualize calibration curves in performance analysis
- include scikit-learn and matplotlib dependencies

## Testing
- `pytest` *(fails: No module named 'sklearn')*
- `pip install scikit-learn matplotlib` *(fails: Could not find a version that satisfies the requirement scikit-learn)*
- `ruff check` *(fails: multiple lint errors, e.g., W293 in test_database.py)*

------
https://chatgpt.com/codex/tasks/task_e_68acf3fef6d0832cb648eb55e58d663f