### PR TITLE
Enable incremental ML training and periodic retraining

### DIFF
--- a/k8s/cronjobs.yaml
+++ b/k8s/cronjobs.yaml
@@ -82,3 +82,21 @@ spec:
             image: itlusions/swing-agent:latest
             command: ["sh", "-c", "python scripts/eval_signals.py && python scripts/analyze_performance.py"]
           restartPolicy: OnFailure
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: swing-agent-train
+spec:
+  schedule: "0 2 * * *"
+  timeZone: "Europe/Amsterdam"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: train
+            image: itlusions/swing-agent:latest
+            command: ["python", "scripts/train_ml_model.py"]
+          restartPolicy: OnFailure

--- a/scripts/train_ml_model.py
+++ b/scripts/train_ml_model.py
@@ -1,0 +1,52 @@
+"""Train or incrementally update an ML model using stored training data."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+from sklearn.linear_model import SGDRegressor
+import joblib
+
+DATA_PATH = Path("data/training_dataset.npz")
+MODEL_PATH = Path("data/ml_model.pkl")
+
+
+def load_training_data(path: Path) -> Tuple[np.ndarray, np.ndarray]:
+    if not path.exists():
+        raise FileNotFoundError(f"Training dataset not found: {path}")
+    data = np.load(path, allow_pickle=True)
+    return data["X"], data["y"]
+
+
+def load_or_initialize(model_path: Path) -> SGDRegressor:
+    if model_path.exists():
+        return joblib.load(model_path)
+    return SGDRegressor()
+
+
+def train_incremental(X: np.ndarray, y: np.ndarray, model_path: Path = MODEL_PATH) -> SGDRegressor:
+    model = load_or_initialize(model_path)
+    if hasattr(model, "partial_fit"):
+        model.partial_fit(X, y)
+    else:
+        model.fit(X, y)
+    joblib.dump(model, model_path)
+    return model
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Train or update the ML model")
+    ap.add_argument("--data", default=str(DATA_PATH))
+    ap.add_argument("--model", default=str(MODEL_PATH))
+    args = ap.parse_args()
+
+    X, y = load_training_data(Path(args.data))
+    train_incremental(X, y, Path(args.model))
+    print(f"Trained model on {len(y)} samples")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Append evaluated signal vectors and outcomes into a cumulative training dataset
- Add script that loads existing model weights and performs partial-fit updates
- Schedule daily CronJob to retrain ML model from accumulated data

## Testing
- `python -m py_compile scripts/eval_signals.py scripts/train_ml_model.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acf46cccb0832c87520e02f2cd146c