### PR TITLE
Add parameter optimization script and enhance backtest metrics

### DIFF
--- a/scripts/optimize_params.py
+++ b/scripts/optimize_params.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+"""Parameter optimization for SwingAgent backtests.
+
+This script evaluates multiple parameter combinations using
+``portfolio_backtest.run_backtest`` and selects the best configuration
+based on average realized R multiple or Sharpe ratio.  Results are
+written to JSON and the global ``TradingConfig`` is updated accordingly.
+"""
+
+import argparse
+import itertools
+import json
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from scripts.portfolio_backtest import run_backtest
+from swing_agent.config import update_config
+
+
+def _parse_ints(values: str) -> Iterable[int]:
+    return [int(v) for v in values.split(",") if v]
+
+
+def grid_search(signals: Path, ema_vals: Iterable[int], rsi_vals: Iterable[int], metric: str):
+    best_score = float("-inf")
+    best_params: dict[str, int] | None = None
+    for ema, rsi in itertools.product(ema_vals, rsi_vals):
+        update_config(EMA20_PERIOD=ema, RSI_PERIOD=rsi)
+        result = run_backtest(signals)
+        score = result["avg_r"] if metric == "realized_r" else result["sharpe"]
+        if score > best_score:
+            best_score = score
+            best_params = {"EMA20_PERIOD": ema, "RSI_PERIOD": rsi}
+    if best_params is None:  # no trades
+        best_params = {"EMA20_PERIOD": ema_vals[0], "RSI_PERIOD": rsi_vals[0]}
+        best_score = 0.0
+    return best_params, best_score
+
+
+def optuna_search(
+    signals: Path,
+    ema_vals: Iterable[int],
+    rsi_vals: Iterable[int],
+    metric: str,
+    trials: int,
+):
+    try:
+        import optuna
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise SystemExit("optuna is required for --use-optuna") from exc
+
+    def objective(trial: "optuna.Trial") -> float:
+        ema = trial.suggest_categorical("EMA20_PERIOD", ema_vals)
+        rsi = trial.suggest_categorical("RSI_PERIOD", rsi_vals)
+        update_config(EMA20_PERIOD=ema, RSI_PERIOD=rsi)
+        result = run_backtest(signals)
+        return result["avg_r"] if metric == "realized_r" else result["sharpe"]
+
+    study = optuna.create_study(direction="maximize")
+    study.optimize(objective, n_trials=trials)
+    return study.best_params, study.best_value
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--signals", required=True, type=Path, help="CSV file with generated signals")
+    ap.add_argument("--ema-periods", default="20", help="Comma separated EMA lengths")
+    ap.add_argument("--rsi-periods", default="14", help="Comma separated RSI periods")
+    ap.add_argument("--metric", choices=["realized_r", "sharpe"], default="realized_r")
+    ap.add_argument("--output", type=Path, default=Path("best_params.json"))
+    ap.add_argument("--use-optuna", action="store_true", help="Use optuna instead of grid search")
+    ap.add_argument("--trials", type=int, default=20, help="Number of optuna trials")
+    args = ap.parse_args()
+
+    ema_vals = list(_parse_ints(args.ema_periods))
+    rsi_vals = list(_parse_ints(args.rsi_periods))
+
+    if args.use_optuna:
+        best_params, best_score = optuna_search(
+            args.signals, ema_vals, rsi_vals, args.metric, args.trials
+        )
+    else:
+        best_params, best_score = grid_search(args.signals, ema_vals, rsi_vals, args.metric)
+
+    # Update global config and persist
+    update_config(**best_params)
+    best_params["score"] = best_score
+    args.output.write_text(json.dumps(best_params, indent=2))
+    print(f"Best parameters: {best_params}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/portfolio_backtest.py
+++ b/scripts/portfolio_backtest.py
@@ -14,6 +14,7 @@ slippage.
 import argparse
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 from swing_agent.risk import sized_quantity
@@ -24,10 +25,12 @@ def run_backtest(
     equity: float = 100_000.0,
     fee_per_trade: float = 1.0,
     slippage_bp: float = 5.0,
-) -> None:
+) -> dict:
     df = pd.read_csv(signals_path, parse_dates=["date"])
     trades = 0
     pnl = 0.0
+    r_multiples: list[float] = []
+    returns: list[float] = []
     for row in df.itertuples():
         qty = sized_quantity(equity, row.entry, row.stop)
         if qty == 0:
@@ -37,17 +40,45 @@ def run_backtest(
         trade_pnl = (row.exit - row.entry) * qty - 2 * fee_per_trade - slippage
         pnl += trade_pnl
         equity += trade_pnl
+        r = (row.exit - row.entry) / max(row.entry - row.stop, 1e-9)
+        r_multiples.append(r)
+        returns.append(trade_pnl / (row.entry * qty))
+    avg_r = float(np.mean(r_multiples)) if r_multiples else 0.0
+    sharpe = (
+        float(np.mean(returns) / np.std(returns) * np.sqrt(len(returns)))
+        if len(returns) > 1 and np.std(returns) != 0
+        else 0.0
+    )
+    result = {
+        "trades": trades,
+        "pnl": pnl,
+        "final_equity": equity,
+        "avg_r": avg_r,
+        "sharpe": sharpe,
+    }
     if trades:
-        print(f"Trades: {trades}  PnL: {pnl:.2f}  Final equity: {equity:.2f}")
+        msg = (
+            f"Trades: {trades}  PnL: {pnl:.2f}  Final equity: {equity:.2f}  "
+            f"Avg R: {avg_r:.3f}  Sharpe: {sharpe:.2f}"
+        )
+        print(msg)
     else:
         print("No trades generated.")
+    return result
 
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
-    ap.add_argument("--signals", required=True, help="CSV file with columns date,symbol,entry,stop,exit")
+    ap.add_argument(
+        "--signals", required=True, help="CSV file with columns date,symbol,entry,stop,exit"
+    )
     ap.add_argument("--equity", type=float, default=100_000.0)
     ap.add_argument("--fee", type=float, default=1.0, help="per-trade fee")
     ap.add_argument("--slippage-bp", type=float, default=5.0, help="slippage in basis points")
     args = ap.parse_args()
-    run_backtest(Path(args.signals), equity=args.equity, fee_per_trade=args.fee, slippage_bp=args.slippage_bp)
+    run_backtest(
+        Path(args.signals),
+        equity=args.equity,
+        fee_per_trade=args.fee,
+        slippage_bp=args.slippage_bp,
+    )


### PR DESCRIPTION
## Summary
- extend portfolio backtest to return trades, average R multiple, and Sharpe ratio
- add `scripts/optimize_params.py` to grid search or Optuna optimize EMA/RSI parameters

## Testing
- `python -m ruff check scripts/portfolio_backtest.py scripts/optimize_params.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68acf4680860832c82fd4746579be1aa